### PR TITLE
replaced strings.Replace() with strings.NewReplacer()

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -62,17 +62,11 @@ func Domain(url string) string {
 // FileName Converts a string to a valid filename
 func FileName(name string) string {
 	// FIXME(iawia002) file name can't have /
-	name = strings.Replace(name, "/", " ", -1)
-	name = strings.Replace(name, "|", "-", -1)
-	name = strings.Replace(name, ": ", "：", -1)
-	name = strings.Replace(name, ":", "：", -1)
+	rep := strings.NewReplacer("/", " ", "|", "-", ": ", "：", ":", "：")
+	name = rep.Replace(name)
 	if runtime.GOOS == "windows" {
-		winSymbols := []string{
-			"\"", "?", "*", "\\", "<", ">",
-		}
-		for _, symbol := range winSymbols {
-			name = strings.Replace(name, symbol, " ", -1)
-		}
+		rep = strings.NewReplacer("\"", " ", "?", " ", "*", " ", "\\", " ", "<", " ", ">", " ")
+		name = rep.Replace(name)
 	}
 	return name
 }


### PR DESCRIPTION
utils.FileName function uses strings.replacer instead of calling strings.replace multiple times