### PR TITLE
modified readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,9 @@
 
 👾 Annie is a fast, simple and clean video downloader built with Go.
 
-Annie allows users to download videos and playlists from supported websites like Bilibili:
-
-```console
-$ annie -c cookies.txt https://www.bilibili.com/video/av20203945/
-
- Site:      哔哩哔哩 bilibili.com
- Title:     【2018拜年祭单品】相遇day by day
- Type:      video
- Stream:
-     [default]  -------------------
-     Quality:         高清 1080P60
-     Size:            220.65 MiB (231363071 Bytes)
-     # download with: annie -f default "URL"
-
- 16.03 MiB / 220.65 MiB [==>----------------------------]   7.26% 9.65 MiB/s 19s
-```
-
-
-* [Install](#install)
-* [Get Started](#get-started)
+* [Installation](#installation)
+* [Getting Started](#getting-started)
+* [Usage](#usage)
 * [Supported Sites](#supported-sites)
 * [Known issues](#known-issues)
 * [About this project](#about-this-project)
@@ -34,7 +17,7 @@ $ annie -c cookies.txt https://www.bilibili.com/video/av20203945/
 * [License](#license)
 
 
-## Install
+## Installation
 
 ### Prerequisites
 
@@ -46,39 +29,40 @@ The following dependencies are required and must be installed separately.
 
 ### Install via `go get`
 
-To install Annie, use `go get`, or download the binary file in the [Releases](https://github.com/iawia002/annie/releases) page.
+To install Annie, use `go get`, or download the binary file from [Releases](https://github.com/iawia002/annie/releases) page.
 
 ```bash
 $ go get github.com/iawia002/annie
-...
-$ annie [args] URL
 ```
 
 
-## Get Started
+## Getting Started
 
 ### Download a video
 
 ```console
-$ annie -s 127.0.0.1:1080 https://youtu.be/Gnbch2osEeo
+$ annie 'https://www.youtube.com/watch?v=v-Dur3uXXCQ'
 
- Site:      YouTube youtube.com
- Title:     Multifandom Mashup 2017
+Site:      YouTube youtube.com
+ Title:     Kesha - Praying (Official Video)
  Type:      video
- Stream:
+ Stream:   
      [default]  -------------------
      Quality:         hd720
-     Size:            57.97 MiB (60785404 Bytes)
+     Size:            50.62 MiB (53080675 Bytes)
      # download with: annie -f default "URL"
 
- 11.93 MiB / 57.97 MiB [======>-------------------------]  20.57% 19.03 MiB/s 2s
+
+ 11.93 MiB / 50.627 MiB [=======>------------------------]  23.6% 18.53 MiB/s 2s
 ```
 
 > Note: wrap the URL in quotation marks if it contains special characters. (thanks @tonyxyl for pointing this out)
 >
 > `$ annie 'https://...'`
 
-The `-i` option displays all available formats information without downloading.
+## Usage
+
+The `-i` option displays all available formats, information without downloading.
 
 ```console
 $ annie -i -s 127.0.0.1:1080 https://youtu.be/Gnbch2osEeo
@@ -353,7 +337,7 @@ I am just a college student and this is one of my amateur projects(I need to fin
 
 ## Contributing
 
-Annie is an open source project and built on the top of open source projects. If you are interested, welcome to contribute, let's make Annie better, together 💪
+Annie is an open source project and built on the top of open source projects. If you are interested, you are welcome to contribute, let's make Annie better, together 💪
 
 Check out the [Contributing Guide](./CONTRIBUTING.md) to get started.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 * [Installation](#installation)
 * [Getting Started](#getting-started)
-* [Usage](#usage)
 * [Supported Sites](#supported-sites)
 * [Known issues](#known-issues)
 * [About this project](#about-this-project)
@@ -34,6 +33,9 @@ To install Annie, use `go get`, or download the binary file from [Releases](http
 ```bash
 $ go get github.com/iawia002/annie
 ```
+### Arch Linux
+
+For Arch Users [AUR](https://aur.archlinux.org/packages/annie) package is available
 
 
 ## Getting Started
@@ -41,26 +43,23 @@ $ go get github.com/iawia002/annie
 ### Download a video
 
 ```console
-$ annie 'https://www.youtube.com/watch?v=v-Dur3uXXCQ'
+$ annie https://youtu.be/Gnbch2osEeo
 
-Site:      YouTube youtube.com
- Title:     Kesha - Praying (Official Video)
+ Site:      YouTube youtube.com
+ Title:     Multifandom Mashup 2017
  Type:      video
- Stream:   
+ Stream:
      [default]  -------------------
      Quality:         hd720
-     Size:            50.62 MiB (53080675 Bytes)
+     Size:            57.97 MiB (60785404 Bytes)
      # download with: annie -f default "URL"
 
-
- 11.93 MiB / 50.627 MiB [=======>------------------------]  23.6% 18.53 MiB/s 2s
+ 11.93 MiB / 57.97 MiB [======>-------------------------]  20.57% 19.03 MiB/s 2s
 ```
 
 > Note: wrap the URL in quotation marks if it contains special characters. (thanks @tonyxyl for pointing this out)
 >
 > `$ annie 'https://...'`
-
-## Usage
 
 The `-i` option displays all available formats, information without downloading.
 


### PR DESCRIPTION
I have done some changes.
The reason I have taken this ,`annie -c cookies.txt https://www.bilibili.com/video/av20203945/`, is because -c option isn't necessary for normal download, it may confuse some users.
Any how the rest is explained under usage section.
Make necessary changes if you didn't like something.