### PR TITLE
Using goreleaser instead of gox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Python
 *.pyc
+dist/
+github_token
+.github_token

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,42 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+project_name: annie
+builds:
+- env:
+  - CGO_ENABLED=0
+  binary: annie
+  goos:
+    - windows
+    - darwin
+    - linux
+    - freebsd
+  goarch:
+    - 386
+    - amd64
+    - arm
+    - arm64
+  ignore:
+    - goos: freebsd
+      goarch: arm
+      goarm: 6
+  hooks:
+    # Please install upx first, https://github.com/upx/upx/releases
+    # post: compress.bat
+    post: ./compress.sh
+archive:
+  name_template: '{{ .ProjectName }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}_v{{ .Arm }}{{ end }}'
+  format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
+  replacements:
+    amd64: 64-bit
+    386: 32-bit
+    arm: ARM
+    arm64: ARM64
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    openbsd: OpenBSD
+    netbsd: NetBSD
+    freebsd: FreeBSD

--- a/compress.bat
+++ b/compress.bat
@@ -1,0 +1,2 @@
+:: Please install upx first, https://github.com/upx/upx/releases
+for /f "delims=" %%i in ('dir /b /a-d /s "annie*"') do upx --best "%%i"

--- a/compress.sh
+++ b/compress.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Please install upx first, https://github.com/upx/upx/releases
+for line in $(find . -iname 'annie*'); do
+     upx --best "$line"
+done


### PR DESCRIPTION
The binary size of release page is too big, so I recommend using goreleaser instead of gox.