### PR TITLE
Add support for Aria2 RPC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 dist/
 github_token
 .github_token
+
+# macOS
+.DS_Store

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,14 @@ var (
 	OutputName string
 	// ExtractedData print extracted data
 	ExtractedData bool
+	// Aria2 RPC
+	UseAria2RPC bool
+	// Aria2 RPC Token
+	Aria2Token string
+	// Aria2 Address, use localhost:6800 as default
+	Aria2Addr string
+	// Aria2 Method, use http as default
+	Aria2Method string
 	// ThreadNumber The number of download thread (only works for multiple-parts video)
 	ThreadNumber int
 	// File URLs file path

--- a/main.go
+++ b/main.go
@@ -46,6 +46,10 @@ func init() {
 	flag.StringVar(&config.OutputPath, "o", "", "Specify the output path")
 	flag.StringVar(&config.OutputName, "O", "", "Specify the output file name")
 	flag.BoolVar(&config.ExtractedData, "j", false, "Print extracted data")
+	flag.BoolVar(&config.UseAria2RPC, "aria2", false, "Use Aria2 RPC to download")
+	flag.StringVar(&config.Aria2Token, "aria2token", "", "Aria2 RPC Token")
+	flag.StringVar(&config.Aria2Addr, "aria2addr", "localhost:6800", "Aria2 Address")
+	flag.StringVar(&config.Aria2Method, "aria2method", "http", "Aria2 Method")
 	flag.IntVar(
 		&config.ThreadNumber, "n", 10, "The number of download thread (only works for multiple-parts video)",
 	)


### PR DESCRIPTION
There are several reports about the download speed would slow down gradually, especially in Bilibili:
https://github.com/iawia002/annie/issues/275 https://github.com/iawia002/annie/issues/143 https://github.com/iawia002/annie/issues/128

I am not an expert in Go and have no idea to improve the application itself. So I tried to use third-party applications to download.

[aria2](https://aria2.github.io) is a very famous and lightweight command-line download utility. It has an interface of RPC, which means we can merely send a request to make it work.

```
  -aria2
    	Use Aria2 RPC to download
  -aria2addr string
    	Aria2 Address (default "localhost:6800")
  -aria2method string
    	Aria2 Method (default "http")
  -aria2token string
    	Aria2 RPC Token
```
Here is the demo:

- Use built-in download:
![](https://wx4.sinaimg.cn/large/9f90340dgy1fw06jjl2u5g20f008n7g3.gif)

- Use aria2c (I use a WebUI, AriaNg to watch the speed):
![](https://i.loli.net/2018/10/08/5bba46b2d1332.gif)

I know that this breaks the independence of annie, but it is an effective workaround to improve the download speed. In addition, I only implemented the download request, leaving the post process empty. Perhaps I would make the function more completed some day or just make it a plugin for annie.

Last but not least, thank you for developing this convenient tool.