### PR TITLE
Trim spaces for video links.

### DIFF
--- a/extractors/youtube/youtube_test.go
+++ b/extractors/youtube/youtube_test.go
@@ -30,7 +30,7 @@ func TestYoutube(t *testing.T) {
 			args: test.Args{
 				URL:     "https://youtu.be/z8eFzkfto2w",
 				Title:   "Circle Of Love | Rudy Mancuso",
-				Size:    32970861,
+				Size:    33060990,
 				Quality: `1080p video/webm; codecs="vp9"`,
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 
@@ -173,10 +174,11 @@ func main() {
 		defer file.Close()
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
-			if scanner.Text() == "" {
+			universal_url := strings.TrimSpace(scanner.Text())
+			if universal_url == "" {
 				continue
 			}
-			args = append(args, scanner.Text())
+			args = append(args, universal_url)
 		}
 	}
 	if len(args) < 1 {
@@ -199,6 +201,6 @@ func main() {
 		}
 	}
 	for _, videoURL := range args {
-		download(videoURL)
+		download(strings.TrimSpace(videoURL))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -174,11 +174,11 @@ func main() {
 		defer file.Close()
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
-			universal_url := strings.TrimSpace(scanner.Text())
-			if universal_url == "" {
+			universalURL := strings.TrimSpace(scanner.Text())
+			if universalURL == "" {
 				continue
 			}
-			args = append(args, universal_url)
+			args = append(args, universalURL)
 		}
 	}
 	if len(args) < 1 {


### PR DESCRIPTION
Avoid the following:

```
$ annie -i -p "    https://www.bilibili.com/bangumi/play/ep198061    "
Downloading     https://www.bilibili.com/bangumi/play/ep198061     error:
parse     https://www.bilibili.com/bangumi/play/ep198061    : invalid URI for request
```

```
$ annie "   https://img9.bcyimg.com/drawer/15294/post/1799t/1f5a87801a0711e898b12b640777720f.jpg   "
Downloading    https://img9.bcyimg.com/drawer/15294/post/1799t/1f5a87801a0711e898b12b640777720f.jpg    error:
parse    https://img9.bcyimg.com/drawer/15294/post/1799t/1f5a87801a0711e898b12b640777720f.jpg   : invalid URI for request

```

```
$ cat video.txt
    https://www.bilibili.com/video/av21877586
	    	https://www.bilibili.com/video/av21990740  

$ annie -F video.txt
Downloading     https://www.bilibili.com/video/av21877586   error:
parse     https://www.bilibili.com/video/av21877586  : invalid URI for request
Downloading 	    	https://www.bilibili.com/video/av21990740   error:
parse 	    	https://www.bilibili.com/video/av21990740  : invalid URI for request

```