### PR TITLE
Fix wrong output name while Aria2 RPC calling

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -210,11 +210,11 @@ func Download(v Data, refer string, chunkSizeMB int) error {
 			urls = append(urls, p.URL)
 		}
 		var inputs Aria2Input
-		inputs.Out = title + "." + data.URLs[0].Ext
 		inputs.Header = append(inputs.Header, "Referer: "+refer)
-		rpcData.Params[2] = &inputs
 		for i := range urls {
 			rpcData.Params[1] = urls[i : i+1]
+			inputs.Out = fmt.Sprintf("%s[%d].%s", title, i, data.URLs[0].Ext)
+			rpcData.Params[2] = &inputs
 			jsonData, err := json.Marshal(rpcData)
 			if err != nil {
 				return err


### PR DESCRIPTION
Output names set to the same file name for every part would cause overrwrite while downloading different parts.  
And filename will be out of order even if set `max-concurrent-downloads=1` and disable `continue` option.