### PR TITLE
youtube: detect login required video

### DIFF
--- a/extractors/defs.go
+++ b/extractors/defs.go
@@ -5,3 +5,4 @@ import (
 )
 
 var ErrURLParseFailed = errors.New("url parse failed")
+var ErrLoginRequired = errors.New("login required")

--- a/extractors/youtube/youtube.go
+++ b/extractors/youtube/youtube.go
@@ -99,6 +99,10 @@ func youtubeDownload(uri string) downloader.Data {
 	}
 	ytplayer := utils.MatchOneOf(html, `;ytplayer\.config\s*=\s*({.+?});`)
 	if ytplayer == nil || len(ytplayer) < 2 {
+		if strings.Contains(html, "LOGIN_REQUIRED") ||
+			strings.Contains(html, "Sign in to confirm your age") {
+			return downloader.EmptyData(uri, extractors.ErrLoginRequired)
+		}
 		return downloader.EmptyData(uri, extractors.ErrURLParseFailed)
 	}
 


### PR DESCRIPTION
some youtube page need user login.
guest will see
```
Sign in to confirm your age
This video may be inappropriate for some users.
```

![image](https://user-images.githubusercontent.com/41882455/70792734-d4484600-1dd4-11ea-9c2b-e879fac0e5ce.png)

and the HTML content will have this:

```
"playabilityStatus":{"status":"LOGIN_REQUIRED","reason":"Sign in to confirm your age","errorScreen":{"playerErrorMessageRenderer":{"subreason":{"runs":[{"text":"This video may be inappropriate for some users."}]},"reason":{"simpleText":"Sign in to confirm your age"}
```

we should notify the user the real reason so that they can have the -c param to load cookies.
not just print `url parse failed` , this does not help

ps:
an example URL:
```
https://www.youtube.com/watch?v=VJdCvboSmR4
```