### PR TITLE
main: trim spaces in config.Cookie

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,7 +230,7 @@ func main() {
 				color.Red("%v", err)
 				return
 			}
-			config.Cookie = string(data)
+			config.Cookie = strings.TrimSpace(string(data))
 		}
 	}
 	var isErr bool


### PR DESCRIPTION
I try to use cookie file with option -c but get error 

> net/http: invalid header field value "xxx\n" for key Cookie

After checking, error comes from [here](https://github.com/golang/go/blob/release-branch.go1.13/src/net/http/transport.go#L476), and the reason is vim adds new line at the end of file by default: https://stackoverflow.com/questions/14171254/why-would-vim-add-a-new-line-at-the-end-of-a-file