### PR TITLE
Youtube merge streams issues

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -248,7 +248,15 @@ func Download(v Data, refer string, chunkSizeMB int) error {
 	}
 
 	// Skip the complete file that has been merged
-	mergedFilePath, err := utils.FilePath(title, "mp4", false)
+	var (
+		mergedFilePath string
+		err            error
+	)
+	if v.Site == "YouTube youtube.com" {
+		mergedFilePath, err = utils.FilePath(title, data.URLs[0].Ext, false)
+	} else {
+		mergedFilePath, err = utils.FilePath(title, "mp4", false)
+	}
 	if err != nil {
 		return err
 	}

--- a/extractors/youtube/youtube.go
+++ b/extractors/youtube/youtube.go
@@ -219,25 +219,78 @@ func extractVideoURLS(data playerResponseType, videoInfo *ytdl.VideoInfo) (map[s
 	// Unlike `url_encoded_fmt_stream_map`, all videos in `adaptive_fmts` have no sound,
 	// we need download video and audio both and then merge them.
 
-	// get audio file for videos in AdaptiveFormats
-	var audio downloader.URL
-	for _, f := range data.StreamingData.AdaptiveFormats {
-		if strings.HasPrefix(f.MimeType, "audio/mp4") {
-			audioURL, err := getRealURL(f, videoInfo, "m4a")
-			if err != nil {
-				return nil, err
+	// Get separate m4a and webm audio streams for videos in AdaptiveFormats.
+	// Prefer medium quality audio over low quality (there is no AUDIO_QUALITY_HIGH).
+	var fM4aMedium, fM4aLow, fWebmMedium, fWebmLow *streamFormat
+	for i, f := range data.StreamingData.AdaptiveFormats {
+		switch {
+		case strings.HasPrefix(f.MimeType, "audio/mp4"):
+			if f.AudioQuality == "AUDIO_QUALITY_MEDIUM" {
+				fM4aMedium = &data.StreamingData.AdaptiveFormats[i]
+			} else {
+				fM4aLow = &data.StreamingData.AdaptiveFormats[i]
 			}
-			audio = *audioURL
+		case strings.HasPrefix(f.MimeType, "audio/webm"):
+			if f.AudioQuality == "AUDIO_QUALITY_MEDIUM" {
+				fWebmMedium = &data.StreamingData.AdaptiveFormats[i]
+			} else {
+				fWebmLow = &data.StreamingData.AdaptiveFormats[i]
+			}
+		}
+
+		if fM4aMedium != nil && fWebmMedium != nil {
 			break
 		}
 	}
 
+	var audioM4a downloader.URL
+	if fM4aMedium != nil {
+		audioURL, err := getRealURL(*fM4aMedium, videoInfo, "m4a")
+		if err != nil {
+			return nil, err
+		}
+		audioM4a = *audioURL
+	} else if fM4aLow != nil {
+		audioURL, err := getRealURL(*fM4aLow, videoInfo, "m4a")
+		if err != nil {
+			return nil, err
+		}
+		audioM4a = *audioURL
+	}
+
+	var audioWebm downloader.URL
+	if fWebmMedium != nil {
+		audioURL, err := getRealURL(*fWebmMedium, videoInfo, "webm")
+		if err != nil {
+			return nil, err
+		}
+		audioWebm = *audioURL
+	} else if fM4aLow != nil {
+		audioURL, err := getRealURL(*fWebmLow, videoInfo, "webm")
+		if err != nil {
+			return nil, err
+		}
+		audioWebm = *audioURL
+	}
+
+	var emptyURL downloader.URL
 	for _, f := range data.StreamingData.AdaptiveFormats {
 		stream, err := genStream(f, videoInfo)
 		if err != nil {
 			return nil, err
 		}
-		stream.URLs = append(stream.URLs, audio)
+
+		// append audio stream only for adaptive video streams (not audio)
+		switch {
+		case strings.HasPrefix(f.MimeType, "video/mp4"):
+			if audioM4a != emptyURL {
+				stream.URLs = append(stream.URLs, audioM4a)
+			}
+		case strings.HasPrefix(f.MimeType, "video/webm"):
+			if audioWebm != emptyURL {
+				stream.URLs = append(stream.URLs, audioWebm)
+			}
+		}
 
 		streams[strconv.Itoa(f.Itag)] = *stream
 	}

--- a/utils/ffmpeg.go
+++ b/utils/ffmpeg.go
@@ -34,7 +34,7 @@ func MergeAudioAndVideo(paths []string, mergedFilePath string) error {
 		cmds = append(cmds, "-i", path)
 	}
 	cmds = append(
-		cmds, "-c:v", "copy", "-c:a", "aac", "-strict", "experimental",
+		cmds, "-c:v", "copy", "-c:a", "copy",
 		mergedFilePath,
 	)
 	return runMergeCmd(exec.Command("ffmpeg", cmds...), paths, "")


### PR DESCRIPTION
Currently adaptive Youtube video streams (without sound) are merged with an audio m4a stream. This creates at least 2 issues:

1. Webm video streams are merged with the m4a audio stream inside an mp4 container. The resulting video does not show up in VLC or Windows Media Player, for instance (only the sound works). Webm video streams (vp8, vp9) should be merged only with webm audio (opus, vorbis) inside an webm container.

2. Audio only streams are also merged with the m4a stream inside an mp4 container, making the file at least twice as large. In this case only the audio stream should be downloaded (without merging it with the m4a stream).

The code in this pull request finds separate m4a and webm audio streams for videos in AdaptiveFormats and then merges them depending on the type of video stream. Furthermore, medium quality audio streams are preferred over low quality ones (there is no AUDIO_QUALITY_HIGH for audio streams on Youtube, as far as I know).
