### PR TITLE
增加了当下载视频时，多线程分段下载的功能

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,8 @@ var (
 	YoukuPassword string
 	// RetryTimes how many times to retry when the download failed
 	RetryTimes int
+
+	MultiThread bool
 )
 
 // FakeHeaders fake http headers

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -241,7 +241,6 @@ func MultiThreadSave(
 			start = end + 1
 			i++
 		}
-
 	}
 	if savedSize > 0 {
 		bar.Add64(savedSize)
@@ -254,12 +253,10 @@ func MultiThreadSave(
 	wgp.Add(l)
 	sig := utils.NewSignal(threadNum)
 	lock := new(sync.Mutex)
-
 	var errs []error
 	for len(unfinishedPart) > 0 {
 		sig.Set()
 		part := unfinishedPart[0]
-
 		unfinishedPart = append(unfinishedPart[:0], unfinishedPart[1:]...)
 		go func(part *FilePartMeta) {
 			file, err := os.OpenFile(fmt.Sprintf("%s.part%f", filePath, part.Index), os.O_APPEND|os.O_CREATE, 0666)
@@ -313,7 +310,6 @@ func MultiThreadSave(
 					}
 					temp += written
 					headers["Range"] = fmt.Sprintf("bytes=%d-%d", temp, end)
-					//time.Sleep(1 * time.Second)
 				}
 				part.Cur = end + 1
 			}

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -218,7 +217,7 @@ func MultiThreadSave(
 				}
 			} else if part.Cur > part.End {
 				// The part saved size greater than the part size, print the error and re-download the part
-				return errors.New(fmt.Sprintf("Part%f saved size greater than the size of this part, please delete the part and re-download", part.Index))
+				return fmt.Errorf("Part%f saved size greater than the size of this part, please delete the part and re-download\n", part.Index)
 			}
 		}
 	} else {
@@ -257,7 +256,7 @@ func MultiThreadSave(
 	for _, part := range unfinishedPart {
 		wgp.Add()
 		go func(part *FilePartMeta) {
-			file, err := os.OpenFile(fmt.Sprintf("%s.part%f", filePath, part.Index), os.O_APPEND|os.O_CREATE, 0666)
+			file, err := os.OpenFile(fmt.Sprintf("%s.part%f", filePath, part.Index), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
 			if err != nil {
 				errs = append(errs, err)
 				return
@@ -348,7 +347,7 @@ func mustReadFile(filepath string, off int64, n int) ([]byte, error) {
 		return nil, err
 	}
 	if readSize < n {
-		return nil, errors.New("There have no such size of chunk.\n")
+		return nil, fmt.Errorf("There have no such size of chunk.\n")
 	}
 	return buf[0:n], nil
 }
@@ -388,7 +387,7 @@ func readDirAllFilePart(filename, extname string) ([]*FilePartMeta, error) {
 
 func mergeMultiPart(filepath string, parts []*FilePartMeta) error {
 	tempFilePath := filepath + ".download"
-	tempFile, err := os.OpenFile(tempFilePath, os.O_APPEND|os.O_CREATE, 0666)
+	tempFile, err := os.OpenFile(tempFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"sync"
@@ -218,7 +219,7 @@ func MultiThreadSave(
 	}
 
 	// Scan all parts
-	parts, err := readDirAllFilePart(fileName, urlData.Ext)
+	parts, err := readDirAllFilePart(filePath, fileName, urlData.Ext)
 	if err != nil {
 		return err
 	}
@@ -372,8 +373,9 @@ func computeEnd(s, chunkSize, max int64) int64 {
 	return end
 }
 
-func readDirAllFilePart(filename, extname string) ([]*FilePartMeta, error) {
-	dir, err := os.Open(config.OutputPath)
+func readDirAllFilePart(filePath, filename, extname string) ([]*FilePartMeta, error) {
+	dirPath := filepath.Dir(filePath)
+	dir, err := os.Open(dirPath)
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +388,7 @@ func readDirAllFilePart(filename, extname string) ([]*FilePartMeta, error) {
 	reg := regexp.MustCompile(fmt.Sprintf("%s.%s.part.+", filename, extname))
 	for _, fn := range fns {
 		if reg.MatchString(fn.Name()) {
-			meta, err := parseFilePartMeta(path.Join(config.OutputPath, fn.Name()), fn.Size())
+			meta, err := parseFilePartMeta(path.Join(dirPath, fn.Name()), fn.Size())
 			if err != nil {
 				return nil, err
 			}

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -258,6 +258,16 @@ func MultiThreadSave(
 			}
 			lastEnd = part.End
 		}
+		if lastEnd != urlData.Size {
+			newPart := &FilePartMeta{
+				Index: parts[len(parts)-1].Index + 1,
+				Start: lastEnd + 1,
+				End:   urlData.Size,
+				Cur:   lastEnd + 1,
+			}
+			parts = append(parts, newPart)
+			unfinishedPart = append(unfinishedPart, newPart)
+		}
 	} else {
 		var start, end, partSize int64
 		var i float32
@@ -294,7 +304,7 @@ func MultiThreadSave(
 	for _, part := range unfinishedPart {
 		wgp.Add()
 		go func(part *FilePartMeta) {
-			file, err := os.OpenFile(fmt.Sprintf("%s.part%f", filePath, part.Index), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
+			file, err := os.OpenFile(filePartPath(filePath, part), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
 			if err != nil {
 				errs = append(errs, err)
 				return

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -259,11 +259,11 @@ func MultiThreadSave(
 			}
 			lastEnd = part.End
 		}
-		if lastEnd != urlData.Size {
+		if lastEnd != urlData.Size-1 {
 			newPart := &FilePartMeta{
 				Index: parts[len(parts)-1].Index + 1,
 				Start: lastEnd + 1,
-				End:   urlData.Size,
+				End:   urlData.Size - 1,
 				Cur:   lastEnd + 1,
 			}
 			parts = append(parts, newPart)

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -396,7 +396,7 @@ func mergeMultiPart(filepath string, parts []*FilePartMeta) error {
 	defer func() {
 		for _, f := range partFiles {
 			f.Close()
-			//os.Remove(f.Name())
+			os.Remove(f.Name())
 		}
 	}()
 	for _, part := range parts {

--- a/downloader/types.go
+++ b/downloader/types.go
@@ -138,3 +138,10 @@ type Aria2Input struct {
 	// For a simple download, only add headers
 	Header []string `json:"header"`
 }
+
+type FilePartMeta struct {
+	Index float32
+	Start int64
+	End   int64
+	Cur   int64
+}

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 )
 
 func init() {
+	flag.BoolVar(&config.MultiThread, "m", false, "Multiple threads to download single video")
 	flag.BoolVar(&config.Debug, "d", false, "Debug mode")
 	flag.BoolVar(&config.Version, "v", false, "Show version")
 	flag.BoolVar(&config.InfoOnly, "i", false, "Information only")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -284,23 +284,3 @@ func Range(min, max int) []int {
 	}
 	return items
 }
-
-type Signal struct {
-	max int
-	c   chan struct{}
-}
-
-func NewSignal(max int) *Signal {
-	return &Signal{
-		max: max,
-		c:   make(chan struct{}, max),
-	}
-}
-
-func (s *Signal) Set() {
-	s.c <- struct{}{}
-}
-
-func (s *Signal) Release() {
-	_ = <-s.c
-}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,8 +6,6 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/tidwall/gjson"
 	"io"
 	"net/url"
 	"os"
@@ -16,6 +14,9 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+
+	"github.com/fatih/color"
+	"github.com/tidwall/gjson"
 
 	"github.com/iawia002/annie/config"
 	"github.com/iawia002/annie/request"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -6,6 +6,8 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"github.com/fatih/color"
+	"github.com/tidwall/gjson"
 	"io"
 	"net/url"
 	"os"
@@ -14,9 +16,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-
-	"github.com/fatih/color"
-	"github.com/tidwall/gjson"
 
 	"github.com/iawia002/annie/config"
 	"github.com/iawia002/annie/request"
@@ -283,4 +282,24 @@ func Range(min, max int) []int {
 		items[index] = min + index
 	}
 	return items
+}
+
+type Signal struct {
+	max int
+	c   chan struct{}
+}
+
+func NewSignal(max int) *Signal {
+	return &Signal{
+		max: max,
+		c:   make(chan struct{}, max),
+	}
+}
+
+func (s *Signal) Set() {
+	s.c <- struct{}{}
+}
+
+func (s *Signal) Release() {
+	_ = <-s.c
 }


### PR DESCRIPTION
1. 使用-m 参数启用多线程下载，线程数量由-n决定
2. 代码上是增加Save的可选版本MultiThreadSave版本。与进度条兼容。
3. MultiThreadSave的实现：
   将文件分成指定的thread数量的part文件，每个part
文件记录着在整个文件中的偏移量，以及本part当前已下载的数据大小。恢复下载时，会同意所有part的信息，以支持继续下载。
当重新启动后，part数量与线程数量不同时，有以下两种情况：
   1. 线程数量小于现存part数，则按线程池调度去完成所有part（使用信号量控制）
   2. 线程数大于现存part数，则多于的线程不启用。
 下载完成后，合并所有part，然后删除part文件（因此可能需要两倍大小的磁盘容量，回续可能优化）
 线程调度方案也可能会优化，以尽量利用可能的线程