### PR TITLE
添加好看视频支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,7 @@ Pornhub | <https://pornhub.com> | ✓ | | | |
 XVIDEOS | <https://xvideos.com> | ✓ | | | |
 聯合新聞網 | <https://udn.com> | ✓ | | | |
 TikTok | <https://www.tiktok.com> | ✓ | | | |
+百度好看 | <https://haokan.baidu.com> | ✓ | | | |
 
 
 ## Known issues

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ Pornhub | <https://pornhub.com> | ✓ | | | |
 XVIDEOS | <https://xvideos.com> | ✓ | | | |
 聯合新聞網 | <https://udn.com> | ✓ | | | |
 TikTok | <https://www.tiktok.com> | ✓ | | | |
-百度好看 | <https://haokan.baidu.com> | ✓ | | | |
+好看视频 | <https://haokan.baidu.com> | ✓ | | | |
 
 
 ## Known issues

--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -1,7 +1,6 @@
 package extractors
 
 import (
-	"github.com/iawia002/annie/extractors/haokan"
 	"net/url"
 	"strings"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/iawia002/annie/extractors/douyu"
 	"github.com/iawia002/annie/extractors/facebook"
 	"github.com/iawia002/annie/extractors/geekbang"
+	"github.com/iawia002/annie/extractors/haokan"
 	"github.com/iawia002/annie/extractors/instagram"
 	"github.com/iawia002/annie/extractors/iqiyi"
 	"github.com/iawia002/annie/extractors/mgtv"

--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -1,6 +1,7 @@
 package extractors
 
 import (
+	"github.com/iawia002/annie/extractors/haokan"
 	"net/url"
 	"strings"
 
@@ -70,6 +71,7 @@ func init() {
 		"xvideos":    xvideos.New(),
 		"udn":        udn.New(),
 		"tiktok":     tiktok.New(),
+		"haokan":     haokan.New(),
 	}
 }
 
@@ -92,7 +94,11 @@ func Extract(u string, option types.Options) ([]*types.Data, error) {
 		if err != nil {
 			return nil, err
 		}
-		domain = utils.Domain(u.Host)
+		if u.Host == "haokan.baidu.com" {
+			domain = "haokan"
+		} else {
+			domain = utils.Domain(u.Host)
+		}
 	}
 	extractor := extractorMap[domain]
 	videos, err := extractor.Extract(u, option)

--- a/extractors/haokan/haokan.go
+++ b/extractors/haokan/haokan.go
@@ -55,16 +55,12 @@ func (e *extractor) Extract(url string, option types.Options) ([]*types.Data, er
 			Size: size,
 		},
 	}
-	contentType, err := request.ContentType(playurl, url)
-	if err != nil {
-		return nil, err
-	}
 
 	return []*types.Data{
 		{
-			Site:    "百度好看 haokan.baidu.com",
+			Site:    "好看视频 haokan.baidu.com",
 			Title:   title,
-			Type:    types.DataType(contentType),
+			Type:    types.DataTypeVideo,
 			Streams: streams,
 			URL:     url,
 		},

--- a/extractors/haokan/haokan.go
+++ b/extractors/haokan/haokan.go
@@ -1,0 +1,69 @@
+package haokan
+
+import (
+	"github.com/iawia002/annie/extractors/types"
+	"github.com/iawia002/annie/request"
+	"github.com/iawia002/annie/utils"
+)
+
+type extractor struct{}
+
+// New returns a haokan extractor.
+func New() types.Extractor {
+	return &extractor{}
+}
+
+// Extract is the main function to extract the data.
+func (e *extractor) Extract(url string, option types.Options) ([]*types.Data, error) {
+	html, err := request.Get(url, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	titles := utils.MatchOneOf(html, `property="og:title"\s+content="(.+?)"`)
+	if titles == nil || len(titles) < 2 {
+		return nil, types.ErrURLParseFailed
+	}
+	title := titles[1]
+
+	urls := utils.MatchOneOf(html, `<video\s*class="video"\s*src="?(.+?)"?\s*>`)
+
+	if urls == nil || len(urls) < 2 {
+		return nil, types.ErrURLParseFailed
+	}
+	playurl := urls[1]
+
+	size, err := request.Size(playurl, url)
+	if err != nil {
+		return nil, err
+	}
+
+	_, ext, err := utils.GetNameAndExt(playurl)
+
+	streams := map[string]*types.Stream{
+		"default": {
+			Parts: []*types.Part{
+				{
+					URL:  playurl,
+					Size: size,
+					Ext:  ext,
+				},
+			},
+			Size: size,
+		},
+	}
+	contentType, err := request.ContentType(playurl, url)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*types.Data{
+		{
+			Site:    "百度好看 haokan.baidu.com",
+			Title:   title,
+			Type:    types.DataType(contentType),
+			Streams: streams,
+			URL:     url,
+		},
+	}, nil
+}

--- a/extractors/haokan/haokan.go
+++ b/extractors/haokan/haokan.go
@@ -39,6 +39,9 @@ func (e *extractor) Extract(url string, option types.Options) ([]*types.Data, er
 	}
 
 	_, ext, err := utils.GetNameAndExt(playurl)
+	if err != nil {
+		return nil, err
+	}
 
 	streams := map[string]*types.Stream{
 		"default": {

--- a/extractors/haokan/haokan_test.go
+++ b/extractors/haokan/haokan_test.go
@@ -1,0 +1,31 @@
+package haokan
+
+import (
+	"testing"
+
+	"github.com/iawia002/annie/extractors/types"
+	"github.com/iawia002/annie/test"
+)
+
+func TestDownload(t *testing.T) {
+	tests := []struct {
+		name string
+		args test.Args
+	}{
+		{
+			name: "normal test",
+			args: test.Args{
+				URL:   "https://haokan.baidu.com/v?vid=12153099833589381848",
+				Title: "你知道吗，十元人民币背后有人的名字，有十元的抓紧看一下吧",
+				Size:  7260836,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := New().Extract(tt.args.URL, types.Options{})
+			test.CheckError(t, err)
+			test.Check(t, tt.args, data[0])
+		})
+	}
+}


### PR DESCRIPTION
你好，我们家老师经常需要从好看视频网站下载资源离线播放给乡村孩子看，所以我新增了对 [好看视频](https://haokan.baidu.com)的支持。

我对go语言不太了解，代码是在 `universal.extractor` 基础上改的，希望有人帮忙review一下。

好看视频下载示例: `annie 'https://haokan.baidu.com/v?vid=7533085269935016859&tab=recommend'`