### PR TITLE
Bilibili dash&4K

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -634,7 +634,7 @@ func (downloader *Downloader) Download(data *types.Data) error {
 	}
 
 	fmt.Printf("Merging video parts into %s\n", mergedFilePath)
-	if stream.Ext != "mp4" || data.Site == "YouTube youtube.com" {
+	if stream.Ext != "mp4" || data.Site == "YouTube youtube.com" || data.Site == "哔哩哔哩 bilibili.com" {
 		return utils.MergeFilesWithSameExtension(parts, mergedFilePath)
 	}
 	return utils.MergeToMP4(parts, mergedFilePath, title)

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	bilibiliAPI = "https://api.bilibili.com/x/player/playurl?"
-	// bilibiliBangumiAPI = "https://bangumi.bilibili.com/player/web_api/v2/playurl?"
+	bilibiliAPI        = "https://api.bilibili.com/x/player/playurl?"
 	bilibiliBangumiAPI = "https://api.bilibili.com/pgc/player/web/playurl?"
 	bilibiliTokenAPI   = "https://api.bilibili.com/x/player/playurl/token?"
 )
@@ -56,55 +55,32 @@ func genAPI(aid, cid, quality int, bangumi bool, seasonType, cookie string) (str
 		}
 		utoken = t.Data.Token
 	}
+	var api string
 	if bangumi {
 		// The parameters need to be sorted by name
 		// qn=0 flag makes the CDN address different every time
-		// quality=116(1080P 60) is the highest quality so far
-		// params = fmt.Sprintf(
-		// 	"appkey=%s&cid=%d&module=bangumi&otype=json&qn=%s&quality=%s&season_type=%s&type=",
-		// 	appKey, cid, quality, quality, seasonType,
-		// )
-		// baseAPIURL = bilibiliBangumiAPI
+		// quality=120(4k) is the highest quality so far
 		params = fmt.Sprintf(
 			"avid=%d&cid=%d&bvid=&qn=%d&type=&otype=json&fourk=1&fnver=0&fnval=16",
 			aid, cid, quality,
 		)
 		baseAPIURL = bilibiliAPI
-		api := baseAPIURL + params
-		return api, nil
 	} else {
-		//avid=200079093&cid=172854601&bvid=&qn=120&type=&otype=json&fourk=1&fnver=0&fnval=16
 		params = fmt.Sprintf(
 			"avid=%d&cid=%d&bvid=&qn=%d&type=&otype=json&fourk=1&fnver=0&fnval=16",
 			aid, cid, quality,
 		)
 		baseAPIURL = bilibiliAPI
-		api := baseAPIURL + params
-		return api, nil
+
 	}
+	api = baseAPIURL + params
 	// bangumi utoken also need to put in params to sign, but the ordinary video doesn't need
-	api := fmt.Sprintf(
-		"%s%s&sign=%s", baseAPIURL, params, utils.Md5(params+secKey),
-	)
 	if !bangumi && utoken != "" {
 		api = fmt.Sprintf("%s&utoken=%s", api, utoken)
 	}
 	return api, nil
 }
 
-// func genBangumiParts(durl []dURLData) ([]*types.Part, int64) {
-// 	var size int64
-// 	parts := make([]*types.Part, len(durl))
-// 	for index, data := range durl {
-// 		size += data.Size
-// 		parts[index] = &types.Part{
-// 			URL:  data.URL,
-// 			Size: data.Size,
-// 			Ext:  "flv",
-// 		}
-// 	}
-// 	return parts, size
-// }
 func genParts(dashData *dashInfo, quality int, referer string) ([]*types.Part, error) {
 	parts := make([]*types.Part, 2)
 	checked := false

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -19,13 +19,6 @@ const (
 	bilibiliTokenAPI   = "https://api.bilibili.com/x/player/playurl/token?"
 )
 
-const (
-	// BiliBili blocks keys from time to time.
-	// You can extract from the Android client or bilibiliPlayer.min.js
-	// appKey = "iVGUTjsxvpLeuDCf"
-	secKey = "aHRmhWMLkdeMuILqORnYZocwMBpMEOdt"
-)
-
 const referer = "https://www.bilibili.com"
 
 var utoken string
@@ -291,8 +284,8 @@ func (e *extractor) Extract(url string, option types.Options) ([]*types.Data, er
 // bilibiliDownload is the download function for a single URL
 func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *types.Data {
 	var (
-		err        error
-		html       string
+		err  error
+		html string
 	)
 	if options.html != "" {
 		// reuse html string, but this can't be reused in case of playlist
@@ -358,9 +351,13 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 		if err != nil {
 			return types.EmptyData(options.url, err)
 		}
+		var size int64
+		for _, part := range parts {
+			size += part.Size
+		}
 		streams[strconv.Itoa(q)] = &types.Stream{
 			Parts:   parts,
-			Size:    0,
+			Size:    size,
 			Quality: qualityString[q],
 		}
 	}

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -337,7 +337,7 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 	// Get "accept_quality" and "accept_description"
 	// "accept_description":["高清 1080P","高清 720P","清晰 480P","流畅 360P"],
 	// "accept_quality":[120,112,80,48,32,16],
-	api, err := genAPI(options.aid, options.cid, 15, options.bangumi, seasonType, extractOption.Cookie)
+	api, err := genAPI(options.aid, options.cid, 120, options.bangumi, seasonType, extractOption.Cookie)
 	if err != nil {
 		return types.EmptyData(options.url, err)
 	}
@@ -363,25 +363,23 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 		if _, ok := streams[strconv.Itoa(q)]; ok {
 			continue
 		}
-		if options.bangumi {
-			api, err := genAPI(options.aid, options.cid, q, options.bangumi, seasonType, extractOption.Cookie)
-			if err != nil {
-				return types.EmptyData(options.url, err)
-			}
-			jsonString, err := request.Get(api, referer, nil)
-			if err != nil {
-				return types.EmptyData(options.url, err)
-			}
+		api, err := genAPI(options.aid, options.cid, q, options.bangumi, seasonType, extractOption.Cookie)
+		if err != nil {
+			return types.EmptyData(options.url, err)
+		}
+		jsonString, err := request.Get(api, referer, nil)
+		if err != nil {
+			return types.EmptyData(options.url, err)
+		}
 
-			err = json.Unmarshal([]byte(jsonString), &data)
-			if err != nil {
-				return types.EmptyData(options.url, err)
-			}
-			if data.Data.Description == nil {
-				dashData = data.Result
-			} else {
-				dashData = data.Data
-			}
+		err = json.Unmarshal([]byte(jsonString), &data)
+		if err != nil {
+			return types.EmptyData(options.url, err)
+		}
+		if data.Data.Description == nil {
+			dashData = data.Result
+		} else {
+			dashData = data.Data
 		}
 		parts, err := genParts(&dashData, q, options.url)
 		if parts == nil {
@@ -391,9 +389,9 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 			return types.EmptyData(options.url, err)
 		}
 		streams[strconv.Itoa(q)] = &types.Stream{
-			Parts:     parts,
-			Size:      0,
-			Quality:   qualityString[q],
+			Parts:   parts,
+			Size:    0,
+			Quality: qualityString[q],
 		}
 	}
 

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -22,7 +22,7 @@ const (
 const (
 	// BiliBili blocks keys from time to time.
 	// You can extract from the Android client or bilibiliPlayer.min.js
-	appKey = "iVGUTjsxvpLeuDCf"
+	// appKey = "iVGUTjsxvpLeuDCf"
 	secKey = "aHRmhWMLkdeMuILqORnYZocwMBpMEOdt"
 )
 
@@ -30,7 +30,7 @@ const referer = "https://www.bilibili.com"
 
 var utoken string
 
-func genAPI(aid, cid, quality int, bangumi bool, seasonType, cookie string) (string, error) {
+func genAPI(aid, cid, quality int, bangumi bool, cookie string) (string, error) {
 	var (
 		err        error
 		baseAPIURL string
@@ -64,14 +64,13 @@ func genAPI(aid, cid, quality int, bangumi bool, seasonType, cookie string) (str
 			"avid=%d&cid=%d&bvid=&qn=%d&type=&otype=json&fourk=1&fnver=0&fnval=16",
 			aid, cid, quality,
 		)
-		baseAPIURL = bilibiliAPI
+		baseAPIURL = bilibiliBangumiAPI
 	} else {
 		params = fmt.Sprintf(
 			"avid=%d&cid=%d&bvid=&qn=%d&type=&otype=json&fourk=1&fnver=0&fnval=16",
 			aid, cid, quality,
 		)
 		baseAPIURL = bilibiliAPI
-
 	}
 	api = baseAPIURL + params
 	// bangumi utoken also need to put in params to sign, but the ordinary video doesn't need
@@ -294,7 +293,6 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 	var (
 		err        error
 		html       string
-		seasonType string
 	)
 	if options.html != "" {
 		// reuse html string, but this can't be reused in case of playlist
@@ -305,15 +303,11 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 			return types.EmptyData(options.url, err)
 		}
 	}
-	if options.bangumi {
-		seasonType = utils.MatchOneOf(html, `"season_type":(\d+)`, `"ssType":(\d+)`)[1]
-
-	}
 
 	// Get "accept_quality" and "accept_description"
 	// "accept_description":["高清 1080P","高清 720P","清晰 480P","流畅 360P"],
 	// "accept_quality":[120,112,80,48,32,16],
-	api, err := genAPI(options.aid, options.cid, 120, options.bangumi, seasonType, extractOption.Cookie)
+	api, err := genAPI(options.aid, options.cid, 120, options.bangumi, extractOption.Cookie)
 	if err != nil {
 		return types.EmptyData(options.url, err)
 	}
@@ -339,7 +333,7 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 		if _, ok := streams[strconv.Itoa(q)]; ok {
 			continue
 		}
-		api, err := genAPI(options.aid, options.cid, q, options.bangumi, seasonType, extractOption.Cookie)
+		api, err := genAPI(options.aid, options.cid, q, options.bangumi, extractOption.Cookie)
 		if err != nil {
 			return types.EmptyData(options.url, err)
 		}

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -54,8 +54,8 @@ func genAPI(aid, cid, quality int, bangumi bool, cookie string) (string, error) 
 		// qn=0 flag makes the CDN address different every time
 		// quality=120(4k) is the highest quality so far
 		params = fmt.Sprintf(
-			"avid=%d&cid=%d&bvid=&qn=%d&type=&otype=json&fourk=1&fnver=0&fnval=16",
-			aid, cid, quality,
+			"cid=%d&bvid=&qn=%d&type=&otype=json&fourk=1&fnver=0&fnval=16",
+			cid, quality,
 		)
 		baseAPIURL = bilibiliBangumiAPI
 	} else {
@@ -134,12 +134,18 @@ func extractBangumi(url, html string, extractOption types.Options) ([]*types.Dat
 		return nil, err
 	}
 	if !extractOption.Playlist {
+		aid := data.EpInfo.Aid
+		cid := data.EpInfo.Cid
+		if aid <= 0 || cid <= 0 {
+			aid = data.EpList[0].Aid
+			cid = data.EpList[0].Cid
+		}
 		options := bilibiliOptions{
 			url:     url,
 			html:    html,
 			bangumi: true,
-			aid:     data.EpInfo.Aid,
-			cid:     data.EpInfo.Cid,
+			aid:     aid,
+			cid:     cid,
 		}
 		return []*types.Data{bilibiliDownload(options, extractOption)}, nil
 	}

--- a/extractors/bilibili/bilibili_test.go
+++ b/extractors/bilibili/bilibili_test.go
@@ -20,17 +20,17 @@ func TestBilibili(t *testing.T) {
 				Title:   "【2018拜年祭单品】相遇day by day",
 				Quality: "高清 1080P",
 			},
-			playlist: true,
+			playlist: false,
 		},
 		{
 			name: "normal test 2",
 			args: test.Args{
 				URL:     "https://www.bilibili.com/video/av41301960",
 				Title:   "【英雄联盟】2019赛季CG 《觉醒》",
-				Size:    85790602,
+				Size:    65774670,
 				Quality: "高清 1080P",
 			},
-			playlist: true,
+			playlist: false,
 		},
 		{
 			name: "bangumi test",
@@ -45,7 +45,7 @@ func TestBilibili(t *testing.T) {
 			args: test.Args{
 				URL:     "https://www.bilibili.com/bangumi/play/ss5050",
 				Title:   "一人之下：第1话 异人刀兵起，道炁携阴阳",
-				Quality: "高清 1080P",
+				Quality: "高清 720P",
 			},
 			playlist: true,
 		},

--- a/extractors/bilibili/types.go
+++ b/extractors/bilibili/types.go
@@ -1,22 +1,5 @@
 package bilibili
 
-type qualityInfo struct {
-	Description []string `json:"accept_description"`
-	Quality     []int    `json:"accept_quality"`
-}
-
-type dURLData struct {
-	Size  int64  `json:"size"`
-	URL   string `json:"url"`
-	Order int    `json:"order"`
-}
-
-type bilibiliData struct {
-	DURL    []dURLData `json:"durl"`
-	Format  string     `json:"format"`
-	Quality int        `json:"quality"`
-}
-
 // {"code":0,"message":"0","ttl":1,"data":{"token":"aaa"}}
 // {"code":-101,"message":"账号未登录","ttl":1}
 type tokenData struct {
@@ -57,7 +40,33 @@ type multiPage struct {
 	VideoData multiPageVideoData `json:"videoData"`
 }
 
+type dashStream struct {
+	ID        int    `json:"id"`
+	BaseURL   string `json:"baseUrl"`
+	Bandwidth int    `json:"bandwidth"`
+}
+
+type dashStreams struct {
+	Video []dashStream `json:"video"`
+	Audio []dashStream `json:"audio"`
+}
+
+type dashInfo struct {
+	CurQuality  int         `json:"quality"`
+	Description []string    `json:"accept_description"`
+	Quality     []int       `json:"accept_quality"`
+	Streams     dashStreams `json:"dash"`
+}
+
+type dash struct {
+	Code    int      `json:"code"`
+	Message string   `json:"message"`
+	Data    dashInfo `json:"data"`
+	Result  dashInfo `json:"result"`
+}
+
 var qualityString = map[int]string{
+	120: "超清 4K",
 	116: "高清 1080P60",
 	74:  "高清 720P60",
 	112: "高清 1080P+",


### PR DESCRIPTION
The old interface is not valid for getting 4K format(#670) or some URL(#716).
Some users also reported that using DASH API to download might be faster. (#684 )
Change the API to the latest DASH API;
Update the extract method for bilibil;

**4K Test**
annie -c cookies.txt -i https://www.bilibili.com/video/av412909688
```
 Site:      哔哩哔哩 bilibili.com
 Title:     【何同学4K】3299真香？iPhone SE使用体验
 Type:      video
 Streams:   # All available quality
     [120]  -------------------
     Quality:         超清 4K
     Size:            275.73 MiB (289127402 Bytes)
     # download with: annie -f 120 ...

     [112]  -------------------
     Quality:         高清 1080P+
     Size:            208.00 MiB (218105640 Bytes)
     # download with: annie -f 112 ...

     [80]  -------------------
     Quality:         高清 1080P
     Size:            29.26 MiB (30676328 Bytes)
     # download with: annie -f 80 ...

     [64]  -------------------
     Quality:         高清 720P
     Size:            21.10 MiB (22125737 Bytes)
     # download with: annie -f 64 ...

     [32]  -------------------
     Quality:         清晰 480P
     Size:            12.11 MiB (12695063 Bytes)
     # download with: annie -f 32 ...

     [16]  -------------------
     Quality:         流畅 360P
     Size:            11.95 MiB (12527097 Bytes)
     # download with: annie -f 16 ...
```
