### PR TITLE
fix(extractors/qq): CDN as referer is invalid to the request for vkey.

### DIFF
--- a/extractors/qq/qq.go
+++ b/extractors/qq/qq.go
@@ -126,7 +126,7 @@ func genStreams(vid, cdn string, data qqVideoInfo) (map[string]*types.Stream, er
 				fmt.Sprintf(
 					"http://vv.video.qq.com/getkey?otype=json&platform=11&appver=%s&filename=%s&format=%d&vid=%s",
 					qqPlayerVersion, filename, fi.ID, vid,
-				), cdn, nil,
+				), "", nil,
 			)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
As mentioned in this [PR](https://github.com/iawia002/annie/pull/725#issuecomment-656511671), the request for key sometimes would retrieve 403 HTTP status. 
Change the referer header to empty in the request for video key is valid.