### PR TITLE
fix(extractors/weibo): some videos dont have multi formats to select #742

### DIFF
--- a/extractors/weibo/weibo.go
+++ b/extractors/weibo/weibo.go
@@ -165,7 +165,7 @@ func downloadWeiboTV(url string) ([]*types.Data, error) {
 		return nil, err
 	}
 
-	if data.Data.PlayInfo.URLs == nil || len(data.Data.PlayInfo.URLs) < 3 {
+	if data.Data.PlayInfo.URLs == nil {
 		return nil, types.ErrURLParseFailed
 	}
 	realURLs := map[string]string{}


### PR DESCRIPTION
The validation of the number of formats is not applicable for some videos.
Remove it as it is unnecessary.