### PR TITLE
fix(extractors/bilibili): Change the parsing method for some videos

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -634,7 +634,7 @@ func (downloader *Downloader) Download(data *types.Data) error {
 	}
 
 	fmt.Printf("Merging video parts into %s\n", mergedFilePath)
-	if stream.Ext != "mp4" || stream.NeedMux == true {
+	if stream.Ext != "mp4" || stream.NeedMux {
 		return utils.MergeFilesWithSameExtension(parts, mergedFilePath)
 	}
 	return utils.MergeToMP4(parts, mergedFilePath, title)

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -634,7 +634,7 @@ func (downloader *Downloader) Download(data *types.Data) error {
 	}
 
 	fmt.Printf("Merging video parts into %s\n", mergedFilePath)
-	if stream.Ext != "mp4" || data.Site == "YouTube youtube.com" || data.Site == "哔哩哔哩 bilibili.com" {
+	if stream.Ext != "mp4" || stream.NeedMux == true {
 		return utils.MergeFilesWithSameExtension(parts, mergedFilePath)
 	}
 	return utils.MergeToMP4(parts, mergedFilePath, title)

--- a/extractors/bilibili/bilibili_test.go
+++ b/extractors/bilibili/bilibili_test.go
@@ -27,7 +27,7 @@ func TestBilibili(t *testing.T) {
 			args: test.Args{
 				URL:     "https://www.bilibili.com/video/av41301960",
 				Title:   "【英雄联盟】2019赛季CG 《觉醒》",
-				Size:    65774670,
+				Size:    62266048,
 				Quality: "高清 1080P",
 			},
 			playlist: false,

--- a/extractors/bilibili/types.go
+++ b/extractors/bilibili/types.go
@@ -51,11 +51,17 @@ type dashStreams struct {
 	Audio []dashStream `json:"audio"`
 }
 
+type dURL struct {
+	Size int64  `json:"size"`
+	URL  string `json:"url"`
+}
+
 type dashInfo struct {
 	CurQuality  int         `json:"quality"`
 	Description []string    `json:"accept_description"`
 	Quality     []int       `json:"accept_quality"`
 	Streams     dashStreams `json:"dash"`
+	DURL        []dURL      `json:"durl"`
 }
 
 type dash struct {

--- a/extractors/types/types.go
+++ b/extractors/types/types.go
@@ -21,6 +21,8 @@ type Stream struct {
 	Size int64 `json:"size"`
 	// the file extension after video parts merged
 	Ext string `json:"ext"`
+	// if the parts need mux
+	NeedMux bool
 }
 
 // DataType indicates the type of extracted data, eg: video or image.

--- a/extractors/youtube/youtube.go
+++ b/extractors/youtube/youtube.go
@@ -228,6 +228,7 @@ func genStream(videoFormat *streamFormat, videoInfo *ytdl.VideoInfo) (*types.Str
 		ID:      strconv.Itoa(videoFormat.Itag),
 		Parts:   []*types.Part{video},
 		Quality: quality,
+		NeedMux: true,
 	}, nil
 }
 


### PR DESCRIPTION
1. DASH API might return the non-separated file, i.e., mp4 and flv, but no m4s files.
2. Using an extra attribute to check if the stream parts need to be muxed into one mp4 file.
3. For some videos, the real resolution and the showing resolution are not matched. 
    For example, in this URL (https://www.bilibili.com/video/BV1Hx411U7xL?p=4), 1080p and 720p files are 960*540 in fact (from [MediaInfo](https://mediaarea.net/en/MediaInfo)). By testing the videos on the browser side (Chrome and Firefox), the problem is the same. Since I do not familiar with the old API, might somebody help to test the old API on these videos?