### PR TITLE
fix issue #791 #782

### DIFF
--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -276,10 +276,9 @@ func (e *extractor) Extract(url string, option types.Options) ([]*types.Data, er
 		return nil, err
 	}
 
-	// set thread number to 1 constantly to avoid http 412 error 
+	// set thread number to 1 manually to avoid http 412 error 
 	option.ThreadNumber = 1
 	fmt.Printf("Warning: Multi thread download is no longer supported by BiliBili, use single thread instead.\n")
-	fmt.Printf("Thread Number: %d\n", option.ThreadNumber)
 
 	if strings.Contains(url, "bangumi") {
 		// handle bangumi

--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -275,6 +275,12 @@ func (e *extractor) Extract(url string, option types.Options) ([]*types.Data, er
 	if err != nil {
 		return nil, err
 	}
+
+	// set thread number to 1 constantly to avoid http 412 error 
+	option.ThreadNumber = 1
+	fmt.Printf("Warning: Multi thread download is no longer supported by BiliBili, use single thread instead.\n")
+	fmt.Printf("Thread Number: %d\n", option.ThreadNumber)
+
 	if strings.Contains(url, "bangumi") {
 		// handle bangumi
 		return extractBangumi(url, html, option)


### PR DESCRIPTION
下载bilibili playlist时，annie默认采用多线程。在Bilibili更新风控策略后，此类多线程下载被视为爬虫，从而导致用户ip被加入黑名单。ip加入黑名单期间，用户访问目标视频将返回http 412错误。
本次修改思路为：在下载bilibili视频时强制使用单线程。在解析bilibili视频时，强制忽略-n 参数，将下载线程数置为1。经测试，可以有效避免返回http 412错误。