### PR TITLE
feat: auto grab cookies from the user's Chrome or Edge

### DIFF
--- a/cookier/cookier.go
+++ b/cookier/cookier.go
@@ -1,0 +1,39 @@
+package cookier
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-rod/rod"
+	"github.com/go-rod/rod/lib/devices"
+	"github.com/go-rod/rod/lib/launcher"
+)
+
+// Get gets cookies from the user's Chrome or Edge automatically.
+// The urls is the list of URLs for which applicable cookies will be fetched.
+func Get(urls ...string) string {
+	path, has := launcher.NewBrowser().LookPath()
+	if !has {
+		return ""
+	}
+
+	u := launcher.NewUserMode().Bin(path).MustLaunch()
+	browser := rod.New().ControlURL(u).MustConnect().DefaultDevice(devices.Clear, false)
+
+	var page *rod.Page
+	pages := browser.MustPages()
+	if pages.Empty() {
+		page = browser.MustPage("")
+		defer page.MustClose()
+	} else {
+		page = pages.First()
+	}
+
+	cookies := page.MustCookies(urls...)
+
+	list := make([]string, 0, len(cookies))
+	for _, c := range cookies {
+		list = append(list, fmt.Sprintf("%s=%s", c.Name, c.Value))
+	}
+	return strings.Join(list, "; ")
+}

--- a/cookier/cookier_test.go
+++ b/cookier/cookier_test.go
@@ -1,0 +1,21 @@
+package cookier
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+var testCookie = flag.Bool("test-cookie", false, "set it to test cookie")
+
+func TestGet(t *testing.T) {
+	if !*testCookie {
+		t.Skip("It's not CI friendly, so we skip it")
+	}
+
+	c := Get("https://www.bilibili.com")
+
+	if !strings.Contains(c, "sid=") {
+		t.Error("cookie should contain the sid")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/andybalholm/cascadia v1.0.0 // indirect
 	github.com/cheggaaa/pb v1.0.25
 	github.com/fatih/color v1.7.0
+	github.com/go-rod/rod v0.77.1
 	github.com/kr/pretty v0.1.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/go-rod/rod v0.77.1 h1:e6QK8KyUaLRswDUDHxW526nDPaP9EvRaaiSce9qm55M=
+github.com/go-rod/rod v0.77.1/go.mod h1:XEc4dRYDxlKw+SFG3ZpWTZ8k4vosgg5IDUHKYPMzVSI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -47,6 +49,16 @@ github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/ysmood/goob v0.3.0 h1:XZ51cZJ4W3WCoCiUktixzMIQF86W7G5VFL4QQ/Q2uS0=
+github.com/ysmood/goob v0.3.0/go.mod h1:S3lq113Y91y1UBf1wj1pFOxeahvfKkCk6mTWTWbDdWs=
+github.com/ysmood/got v0.8.3 h1:YpbQUEKhBXC+BBQJXLpJeg21qDcAT17B90ybmuN0nTk=
+github.com/ysmood/got v0.8.3/go.mod h1:pE1l4LOwOBhQg6A/8IAatkGp7uZjnalzrZolnlhhMgY=
+github.com/ysmood/gotrace v0.1.1 h1:1H9L1Rc0o/80+2Vtm3vn85rNVpNOo94/wf+G5qW0JY8=
+github.com/ysmood/gotrace v0.1.1/go.mod h1:TzhIG7nHDry5//eYZDYcTzuJLYQIkykJzCRIo4/dzQM=
+github.com/ysmood/gson v0.6.3 h1:4cU+5oOdsyundXHy00t99H0rLXLthuseD3x6W+xmCiU=
+github.com/ysmood/gson v0.6.3/go.mod h1:3Kzs5zDl21g5F/BlLTNcuAGAYLKt2lV5G8D1zF3RNmg=
+github.com/ysmood/leakless v0.6.3 h1:blW3g7NYSTkXtRhmV0vq+t4KzWWUJUdd2pB77O0uteQ=
+github.com/ysmood/leakless v0.6.3/go.mod h1:eOWmPkwrQgyJ+JivIgpu5EoJXRN04Wf+wENtR9CUKyE=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -57,6 +69,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191104094858-e8c54fb511f6 h1:ZJUmhYTp8GbGC0ViZRc2U+MIYQ8xx9MscsdXnclfIhw=
 golang.org/x/sys v0.0.0-20191104094858-e8c54fb511f6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200828194041-157a740278f4 h1:kCCpuwSAoYJPkNc6x0xT9yTtV4oKtARo4RGBQWOfg9E=
+golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/main.go
+++ b/main.go
@@ -9,7 +9,9 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/go-rod/rod"
 
+	"github.com/iawia002/annie/cookier"
 	"github.com/iawia002/annie/downloader"
 	"github.com/iawia002/annie/extractors"
 	"github.com/iawia002/annie/extractors/types"
@@ -239,6 +241,11 @@ func main() {
 			}
 			cookie = strings.TrimSpace(string(data))
 		}
+	} else {
+		// Try to use current user's cookie if possible, if failed empty cookie will be used
+		_ = rod.Try(func() {
+			cookie = cookier.Get(args...)
+		})
 	}
 
 	request.SetOptions(request.Options{


### PR DESCRIPTION
The only requirement to use this feature is to close Chrome or Edge once ([why](https://github.com/go-rod/rod/blob/70da96e1b0ead2e656c99095c0969682db77f542/lib/examples/use-rod-like-chrome-extension/main.go#L21)), doesn't support other browsers yet.

This feature is completely transparent to users, when it doesn't work annie won't be affected by it at all.

As you can see, I cd to the root of the repo and run without the "-c" flag, I can still get the 4K video:

```bash
$ go run . -i https://www.bilibili.com/video/BV1fK4y1t7hj
Warning: Multi thread download is no longer supported by BiliBili, use single thread instead.

 Site:      哔哩哔哩 bilibili.com
 Title:     活动作品【4K 120FPS】你的设备顶得住吗？4K120帧技术演示片
 Type:      video
 Streams:   # All available quality
     [120]  -------------------
     Quality:         超清 4K
     Size:            494.55 MiB (518571288 Bytes)
     # download with: annie -f 120 ...

...
```