### PR TITLE
extractors/bilibili: fix low quality audio issue #790 and incorrect muxed video size info bug

### DIFF
--- a/extractors/bilibili/bilibili.go
+++ b/extractors/bilibili/bilibili.go
@@ -276,7 +276,7 @@ func (e *extractor) Extract(url string, option types.Options) ([]*types.Data, er
 		return nil, err
 	}
 
-	// set thread number to 1 manually to avoid http 412 error 
+	// set thread number to 1 manually to avoid http 412 error
 	option.ThreadNumber = 1
 	fmt.Printf("Warning: Multi thread download is no longer supported by BiliBili, use single thread instead.\n")
 
@@ -337,9 +337,9 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 		for _, stream := range dashData.Streams.Audio {
 			if stream.Bandwidth > bandwidth {
 				audioID = stream.ID
+				bandwidth = stream.Bandwidth
 			}
 			audios[stream.ID] = stream.BaseURL
-			bandwidth = stream.Bandwidth
 		}
 		s, err := request.Size(audios[audioID], referer)
 		if err != nil {
@@ -383,12 +383,12 @@ func bilibiliDownload(options bilibiliOptions, extractOption types.Options) *typ
 		if err != nil {
 			return types.EmptyData(options.url, err)
 		}
+		if audioPart != nil {
+			parts = append(parts, audioPart)
+		}
 		var size int64
 		for _, part := range parts {
 			size += part.Size
-		}
-		if audioPart != nil {
-			parts = append(parts, audioPart)
 		}
 		streams[strconv.Itoa(q)] = &types.Stream{
 			Parts:   parts,

--- a/extractors/bilibili/bilibili_test.go
+++ b/extractors/bilibili/bilibili_test.go
@@ -27,7 +27,7 @@ func TestBilibili(t *testing.T) {
 			args: test.Args{
 				URL:     "https://www.bilibili.com/video/av41301960",
 				Title:   "【英雄联盟】2019赛季CG 《觉醒》",
-				Size:    62266048,
+				Size:    70696896,
 				Quality: "高清 1080P",
 			},
 			playlist: false,


### PR DESCRIPTION
* fix low quality audio issue #790
* fix incorrect muxed video size info bug introduced in e463c203f9956c14a6230e513af1cea0e0598bb1