### PR TITLE
adjust haokan url parsing

### DIFF
--- a/extractors/haokan/haokan.go
+++ b/extractors/haokan/haokan.go
@@ -1,6 +1,8 @@
 package haokan
 
 import (
+	"strings"
+
 	"github.com/iawia002/annie/extractors/types"
 	"github.com/iawia002/annie/request"
 	"github.com/iawia002/annie/utils"
@@ -26,12 +28,19 @@ func (e *extractor) Extract(url string, option types.Options) ([]*types.Data, er
 	}
 	title := titles[1]
 
+	// 之前的好看网页中，视频地址是放在 video 标签下
 	urls := utils.MatchOneOf(html, `<video\s*class="video"\s*src="?(.+?)"?\s*>`)
+
+	if urls == nil || len(urls) < 2 {
+		// fallbak: 新的好看网页中，视频地址在 json 数据里
+		urls = utils.MatchOneOf(html, `"playurl":"(http.+?)"`)
+	}
 
 	if urls == nil || len(urls) < 2 {
 		return nil, types.ErrURLParseFailed
 	}
-	playurl := urls[1]
+
+	playurl := strings.Replace(urls[1], `\/`, `/`, -1)
 
 	size, err := request.Size(playurl, url)
 	if err != nil {

--- a/extractors/haokan/haokan_test.go
+++ b/extractors/haokan/haokan_test.go
@@ -15,9 +15,9 @@ func TestDownload(t *testing.T) {
 		{
 			name: "normal test",
 			args: test.Args{
-				URL:   "https://haokan.baidu.com/v?vid=12153099833589381848",
-				Title: "你知道吗，十元人民币背后有人的名字，有十元的抓紧看一下吧",
-				Size:  7260836,
+				URL:   "https://haokan.baidu.com/v?vid=10057409468467026969",
+				Title: "听歌学英语小学篇（6）：my new pen pal",
+				Size:  2027354,
 			},
 		},
 	}


### PR DESCRIPTION
好看视频先前的视频地址位于 `video` 标签下，现在已经改为放在了 `JSON` 数据里，所以调整一下解析方式，改为两种都支持。

测试通过：

![image](https://user-images.githubusercontent.com/2532886/98431622-07cd4680-20f2-11eb-8bfe-0ad4377222e1.png)

