### PR TITLE
fix(utils/utils): use color.Output to handle escape sequence on Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -193,7 +193,8 @@ func download(videoURL string) error {
 }
 
 func printError(url string, err error) {
-	fmt.Printf(
+	fmt.Fprintf(
+		color.Output,
 		"Downloading %s error:\n%s\n",
 		color.CyanString("%s", url), color.RedString("%v", err),
 	)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -258,7 +258,8 @@ func M3u8URLs(uri string) ([]string, error) {
 func PrintVersion() {
 	blue := color.New(color.FgBlue)
 	cyan := color.New(color.FgCyan)
-	fmt.Printf(
+	fmt.Fprintf(
+		color.Output,
 		"\n%s: version %s, A fast, simple and clean video downloader.\n\n",
 		cyan.Sprintf("annie"),
 		blue.Sprintf(config.VERSION),


### PR DESCRIPTION
This PR focuses on the colorized outputs in Windows CMD and PowerShell.

*But I'm not sure if it will break on non-Windows system. I have only tested on my windows and centos.*

## Issue

`annie -v` doesn't print the colorized version info correctly in Windows CMD and PowerShell, but other commands such as `annie -i` works well.

- CMD
  ![1](https://user-images.githubusercontent.com/23522476/98458405-48e55980-21cb-11eb-9820-09c2627be065.png)
- PowerShell
  ![2](https://user-images.githubusercontent.com/23522476/98458407-4a168680-21cb-11eb-8bca-4c2b9689593e.png)

## Reason

- `annie -v` calls `PrintVersion()` to print version info:
  https://github.com/iawia002/annie/blob/d0d473ae01e75b83a14066a37ab85da6a1a0f3c0/utils/utils.go#L258-L266
  
- `annie -i` calls `printStream()` to print stream info:
  https://github.com/iawia002/annie/blob/d0d473ae01e75b83a14066a37ab85da6a1a0f3c0/downloader/utils.go#L40-L50

In `PrintVersion()` , CMD can't handle escape sequence strings provided by `cyan/blue.Sprintf()` . However, in `printStream()` , directly using `cyan/blue.Printf()` works well. That is because the package `color` invokes `fmt.Fprintf(color.Output, format string, a ...interface{})` to print colorized strings:

- https://github.com/fatih/color/blob/v1.7.0/color.go#L224-L229
  
  ```go
  // Printf formats according to a format specifier and writes to standard output.
  // It returns the number of bytes written and any write error encountered.
  // This is the standard fmt.Printf() method wrapped with the given color.
  func (c *Color) Printf(format string, a ...interface{}) (n int, err error) {
  	c.Set()
  	defer c.unset()

  	return fmt.Fprintf(Output, format, a...)
  }
  ```

- https://github.com/fatih/color/blob/v1.7.0/color.go#L25

  ```go
  // Output defines the standard output of the print functions. By default
  // os.Stdout is used.
  Output = colorable.NewColorableStdout()
  ```

So just use `Fprintf` with `color.Output` instead of `Printf` in `PrintVersion()`:

```go
fmt.Fprintf(
    color.Output,
    "\n%s: version %s, A fast, simple and clean video downloader.\n\n",
    cyan.Sprintf("annie"),
    blue.Sprintf(config.VERSION),
) `
```

And similar issue to `printError()`:
https://github.com/iawia002/annie/blob/d0d473ae01e75b83a14066a37ab85da6a1a0f3c0/main.go#L195-L200

## Intuitive test

Here are some test codes and screenshots (from CMD):

### `PrintVersion()`

```go
func PrintVersion() {
	blue := color.New(color.FgBlue)
	cyan := color.New(color.FgCyan)

	// New method 1
	fmt.Fprintf(
		color.Output,
		"\n%s: version %s, A fast, simple and clean video downloader.\n\n",
		cyan.Sprintf("annie"),
		blue.Sprintf(config.VERSION),
	)

	// New method 2
	// just like https://github.com/iawia002/annie/blob/d0d473ae01e75b83a14066a37ab85da6a1a0f3c0/request/request.go#L110-L118
	fmt.Println()
	cyan.Printf("annie")
	fmt.Print(": version ")
	blue.Printf(config.VERSION)
	fmt.Println(", A fast, simple and clean video downloader.\n")

	// Original method
	fmt.Printf(
		"\n%s: version %s, A fast, simple and clean video downloader.\n\n",
		cyan.Sprintf("annie"),
		blue.Sprintf(config.VERSION),
	)
}
```

![3](https://user-images.githubusercontent.com/23522476/98458403-44b93c00-21cb-11eb-8d6d-ece801aa52d5.png)

### `PrintError()`

```go
func printError(url string, err error) {
	// New method 1
	fmt.Fprintf(
		color.Output,
		"Downloading %s error:\n%s\n",
		color.CyanString("%s", url), color.RedString("%v", err),
	)
	fmt.Println()

	// Original method
	fmt.Printf(
		"Downloading %s error:\n%s\n",
		color.CyanString("%s", url), color.RedString("%v", err),
	)
	fmt.Println()
}
```

Try to download a YouTube video without proxy:

![4](https://user-images.githubusercontent.com/23522476/98458404-47b42c80-21cb-11eb-904b-99219fd2493d.png)

## References

1. [fatih/color/README.md at v1.7.0](https://github.com/fatih/color/blob/v1.7.0/README.md#insert-into-noncolor-strings-sprintfunc)
2. https://github.com/fatih/color/issues/91
3. https://github.com/golangci/golangci-lint/issues/14
