### PR TITLE
Fix connection leak

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -172,6 +172,7 @@ func Headers(url, refer string) (http.Header, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close() // nolint
 	return res.Header, nil
 }
 


### PR DESCRIPTION
The `Body` of `res` in `request.Headers` is not closed properly and this might cause the leak of HTTP connections