### PR TITLE
add bvid resolving at bilibili

### DIFF
--- a/extractors/bilibili/types.go
+++ b/extractors/bilibili/types.go
@@ -13,10 +13,11 @@ type token struct {
 }
 
 type bangumiEpData struct {
-	Aid  int `json:"aid"`
-	Cid  int `json:"cid"`
-	ID   int `json:"id"`
-	EpID int `json:"ep_id"`
+	Aid  int    `json:"aid"`
+	Cid  int    `json:"cid"`
+	BVid string `json:"bvid"`
+	ID   int    `json:"id"`
+	EpID int    `json:"ep_id"`
 }
 
 type bangumiData struct {
@@ -37,6 +38,7 @@ type multiPageVideoData struct {
 
 type multiPage struct {
 	Aid       int                `json:"aid"`
+	BVid      string             `json:"bvid"`
 	VideoData multiPageVideoData `json:"videoData"`
 }
 


### PR DESCRIPTION
I try to download https://www.bilibili.com/bangumi/play/ep366031 at bilibili, but it failed:
```
URL:         https://api.bilibili.com/pgc/player/web/playurl?cid=258893183&bvid=&qn=120&type=&otype=json&fourk=1&fnver=0&fnval=16
Method:      GET
Headers:     http.Header{
    "Accept-Language": {"en-US,en;q=0.8"},
    "User-Agent":      {"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36"},
    "Accept":          {"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
    "Accept-Charset":  {"UTF-8,*;q=0.5"},
    "Accept-Encoding": {"gzip,deflate,sdch"},
    "Referer":         {"https://www.bilibili.com"},
}
Status Code: 200
Downloading https://www.bilibili.com/bangumi/play/ep366031 error:                                       
request error: Get "": unsupported protocol scheme ""
```
I found it caused by bvid losing. So I added the code of bvid resolving.