### PR TITLE
Acfun extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,29 +24,45 @@
 
 👾 Annie is a fast, simple and clean video downloader built with Go.
 
-* [Installation](#installation)
-* [Getting Started](#getting-started)
-  * [Download a video](#download-a-video)
-  * [Download anything else](#download-anything-else)
-  * [Download playlist](#download-playlist)
-  * [Multiple inputs](#multiple-inputs)
-  * [Resume a download](#resume-a-download)
-  * [Cookies](#cookies)
-  * [Auto retry](#auto-retry)
-  * [Proxy](#proxy)
-  * [Multi-Thread](#multi-thread)
-  * [Short link](#short-link)
-  * [Use specified Referrer](#use-specified-referrer)
-  * [Specify the output path and name](#specify-the-output-path-and-name)
-  * [Debug Mode](#debug-mode)
-  * [Reuse extracted data](#reuse-extracted-data)
-  * [Options](#options)
-* [Supported Sites](#supported-sites)
-* [Known issues](#known-issues)
-* [Contributing](#contributing)
-* [Authors](#authors)
-* [Similar projects](#similar-projects)
-* [License](#license)
+- [Installation](#installation)
+  - [Prerequisites](#prerequisites)
+  - [Install via `go get`](#install-via-go-get)
+  - [Homebrew (macOS only)](#homebrew-macos-only)
+  - [Arch Linux](#arch-linux)
+  - [Void Linux](#void-linux)
+  - [Scoop on Windows](#scoop-on-windows)
+  - [Chocolatey on Windows](#chocolatey-on-windows)
+- [Getting Started](#getting-started)
+  - [Download a video](#download-a-video)
+  - [Download anything else](#download-anything-else)
+  - [Download playlist](#download-playlist)
+  - [Multiple inputs](#multiple-inputs)
+  - [Resume a download](#resume-a-download)
+  - [Auto retry](#auto-retry)
+  - [Cookies](#cookies)
+  - [Proxy](#proxy)
+  - [Multi-Thread](#multi-thread)
+  - [Short link](#short-link)
+    - [bilibili](#bilibili)
+  - [Use specified Referrer](#use-specified-referrer)
+  - [Specify the output path and name](#specify-the-output-path-and-name)
+  - [Debug Mode](#debug-mode)
+  - [Reuse extracted data](#reuse-extracted-data)
+  - [Options](#options)
+    - [Download:](#download)
+    - [Network:](#network)
+    - [Playlist:](#playlist)
+    - [Filesystem:](#filesystem)
+    - [Subtitle:](#subtitle)
+    - [Youku:](#youku)
+    - [aria2:](#aria2)
+- [Supported Sites](#supported-sites)
+- [Known issues](#known-issues)
+  - [优酷](#优酷)
+- [Contributing](#contributing)
+- [Authors](#authors)
+- [Similar projects](#similar-projects)
+- [License](#license)
 
 
 ## Installation
@@ -610,6 +626,7 @@ XVIDEOS | <https://xvideos.com> | ✓ | | | |
 聯合新聞網 | <https://udn.com> | ✓ | | | |
 TikTok | <https://www.tiktok.com> | ✓ | | | |
 好看视频 | <https://haokan.baidu.com> | ✓ | | | |
+AcFun | <https://www.acfun.cn> | ✓ | | ✓ | |
 
 
 ## Known issues

--- a/extractors/acfun/acfun.go
+++ b/extractors/acfun/acfun.go
@@ -113,9 +113,6 @@ func extractBangumi(URL string, option types.Options) *types.Data {
 		// There is no size information in the m3u8 file and the calculation will take too much time, just ignore it.
 		parts := make([]*types.Part, 0)
 		for _, u := range urls {
-			if err != nil {
-				return types.EmptyData(URL, err)
-			}
 			parts = append(parts, &types.Part{
 				URL: u,
 				Ext: "ts",

--- a/extractors/acfun/acfun.go
+++ b/extractors/acfun/acfun.go
@@ -110,9 +110,7 @@ func extractBangumi(URL string, option types.Options) *types.Data {
 			}
 		}
 
-		// These is no size information in m3u8 file,
-		// and calculating casts too much time,
-		// just omit it.
+		// There is no size information in the m3u8 file and the calculation will take too much time, just ignore it.
 		parts := make([]*types.Part, 0)
 		for _, u := range urls {
 			if err != nil {

--- a/extractors/acfun/acfun.go
+++ b/extractors/acfun/acfun.go
@@ -1,0 +1,177 @@
+package acfun
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/iawia002/annie/extractors/types"
+	"github.com/iawia002/annie/parser"
+	"github.com/iawia002/annie/request"
+	"github.com/iawia002/annie/utils"
+	jsoniter "github.com/json-iterator/go"
+)
+
+const (
+	bangumiDataPattern   = "window.pageInfo = window.bangumiData = (.*);"
+	qualityConfigPattern = "window.qualityConfig = (.*);"
+	bangumiListPattern   = "window.bangumiList = (.*);"
+
+	bangumiHTMLURL  = "https://www.acfun.cn/bangumi/aa%d_36188_%d"
+	bangumiVideoURL = "https://%s/mediacloud/acfun/acfun_video/hls/"
+
+	referer = "https://www.acfun.cn"
+	host    = "https://www.acfun.cn"
+)
+
+type extractor struct{}
+
+// New returns a new acfun bangumi extractor
+func New() types.Extractor {
+	return &extractor{}
+}
+
+func (e *extractor) Extract(URL string, option types.Options) ([]*types.Data, error) {
+	html, err := request.GetByte(URL, referer, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	epDatas := make([]*episodeData, 0)
+
+	if option.Playlist {
+		list, err := resolvingEpisodes(html)
+		if err != nil {
+			return nil, err
+		}
+		items := utils.NeedDownloadList(option.Items, option.ItemStart, option.ItemEnd, len(list.Episodes))
+
+		for _, item := range items {
+			epDatas = append(epDatas, list.Episodes[item-1])
+		}
+	} else {
+		bgData, _, err := resolvingData(html)
+		if err != nil {
+			return nil, err
+		}
+		epDatas = append(epDatas, &bgData.episodeData)
+	}
+
+	datas := make([]*types.Data, 0)
+
+	wgp := utils.NewWaitGroupPool(option.ThreadNumber)
+	for _, epData := range epDatas {
+		t := epData
+		wgp.Add()
+		go func() {
+			defer wgp.Done()
+			datas = append(datas, extractBangumi(concatURL(t), option))
+		}()
+	}
+	wgp.Wait()
+	return datas, nil
+}
+
+func concatURL(epData *episodeData) string {
+	return fmt.Sprintf(bangumiHTMLURL, epData.BangumiID, epData.ItemID)
+}
+
+func extractBangumi(URL string, option types.Options) *types.Data {
+	var err error
+	html, err := request.GetByte(URL, referer, nil)
+	if err != nil {
+		return types.EmptyData(URL, err)
+	}
+
+	_, vInfo, err := resolvingData(html)
+	if err != nil {
+		return types.EmptyData(URL, err)
+	}
+
+	streams := make(map[string]*types.Stream)
+
+	for _, stm := range vInfo.AdaptationSet[0].Streams {
+		m3u8URL, err := url.Parse(stm.URL)
+		if err != nil {
+			return types.EmptyData(URL, err)
+		}
+
+		urls, err := utils.M3u8URLs(m3u8URL.String())
+		if err != nil {
+
+			m3u8URL, err = url.Parse(stm.URL)
+			if err != nil {
+				return types.EmptyData(URL, err)
+			}
+
+			urls, err = utils.M3u8URLs(stm.BackURL)
+			if err != nil {
+				return types.EmptyData(URL, err)
+			}
+		}
+
+		// These is no size information in m3u8 file,
+		// and calculating casts too much time,
+		// just omit it.
+		parts := make([]*types.Part, 0)
+		for _, u := range urls {
+			if err != nil {
+				return types.EmptyData(URL, err)
+			}
+			parts = append(parts, &types.Part{
+				URL: u,
+				Ext: "ts",
+			})
+		}
+		streams[stm.QualityLabel] = &types.Stream{
+			ID:      stm.QualityType,
+			Parts:   parts,
+			Quality: stm.QualityType,
+			NeedMux: false,
+		}
+	}
+
+	doc, err := parser.GetDoc(string(html))
+	if err != nil {
+		return types.EmptyData(URL, err)
+	}
+	data := &types.Data{
+		Site:    "AcFun acfun.cn",
+		Title:   parser.Title(doc),
+		Type:    types.DataTypeVideo,
+		Streams: streams,
+		URL:     URL,
+	}
+	return data
+}
+
+func resolvingData(html []byte) (*bangumiData, *videoInfo, error) {
+	bgData := &bangumiData{}
+	vInfo := &videoInfo{}
+
+	pattern, _ := regexp.Compile(bangumiDataPattern)
+
+	groups := pattern.FindSubmatch(html)
+	err := jsoniter.Unmarshal(groups[1], bgData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = jsoniter.UnmarshalFromString(bgData.CurrentVideoInfo.KsPlayJSON, vInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bgData, vInfo, nil
+}
+
+func resolvingEpisodes(html []byte) (*episodeList, error) {
+	list := &episodeList{}
+	pattern, _ := regexp.Compile(bangumiListPattern)
+
+	groups := pattern.FindSubmatch(html)
+	err := jsoniter.Unmarshal(groups[1], list)
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
+}

--- a/extractors/acfun/acfun_test.go
+++ b/extractors/acfun/acfun_test.go
@@ -1,0 +1,30 @@
+package acfun
+
+import (
+	"testing"
+
+	"github.com/iawia002/annie/extractors/types"
+	"github.com/iawia002/annie/test"
+)
+
+func TestDownload(t *testing.T) {
+	tests := []struct {
+		name string
+		args test.Args
+	}{
+		{
+			name: "normal test",
+			args: test.Args{
+				URL:   "https://www.acfun.cn/bangumi/aa6000686_36188_1704167",
+				Title: "瑞克和莫蒂 第四季 ：第2话 注释版",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := New().Extract(tt.args.URL, types.Options{})
+			test.CheckError(t, err)
+			test.Check(t, tt.args, data[0])
+		})
+	}
+}

--- a/extractors/acfun/types.go
+++ b/extractors/acfun/types.go
@@ -1,0 +1,38 @@
+package acfun
+
+type episodeData struct {
+	ItemID      int64  `json:"itemId"`
+	EpisodeName string `json:"episodeName"`
+	BangumiID   int64  `json:"bangumiId"`
+	VideoID     int64  `json:"videoId"`
+}
+
+type bangumiData struct {
+	episodeData
+	BangumiTitle     string `json:"bangumiTitle"`
+	CurrentVideoInfo struct {
+		KsPlayJSON string `json:"ksPlayJson"`
+	} `json:"currentVideoInfo"`
+}
+
+type videoInfo struct {
+	AdaptationSet []struct {
+		Streams streams `json:"representation"`
+	} `json:"adaptationSet"`
+}
+
+type streams []stream
+
+type episodeList struct {
+	Episodes []*episodeData `json:"items"`
+}
+
+type stream struct {
+	ID           int64  `json:"id"`
+	BackURL      string `json:"backUrl"`
+	Codecs       string `json:"codecs"`
+	URL          string `json:"url"`
+	BitRate      int64  `json:"avgBitrate"`
+	QualityType  string `json:"qualityType"`
+	QualityLabel string `json:"qualityLabel"`
+}

--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/iawia002/annie/extractors/acfun"
 	"github.com/iawia002/annie/extractors/bcy"
 	"github.com/iawia002/annie/extractors/bilibili"
 	"github.com/iawia002/annie/extractors/douyin"
@@ -72,6 +73,7 @@ func init() {
 		"udn":        udn.New(),
 		"tiktok":     tiktok.New(),
 		"haokan":     haokan.New(),
+		"acfun":      acfun.New(),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cheggaaa/pb v1.0.25
 	github.com/fatih/color v1.7.0
 	github.com/go-rod/rod v0.77.1
+	github.com/json-iterator/go v1.1.10
 	github.com/kr/pretty v0.1.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,14 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/go-rod/rod v0.77.1 h1:e6QK8KyUaLRswDUDHxW526nDPaP9EvRaaiSce9qm55M=
 github.com/go-rod/rod v0.77.1/go.mod h1:XEc4dRYDxlKw+SFG3ZpWTZ8k4vosgg5IDUHKYPMzVSI=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
+github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -28,6 +32,10 @@ github.com/mattn/go-runewidth v0.0.6 h1:V2iyH+aX9C5fsYCpK60U8BYIvmhqxuOL3JZcqc1N
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mihaiav/ytdl v0.6.3-0.20200510100116-5f2bf8b4fec0 h1:2w0EKolK4KUQu+A0Jc7XCBRteLIpobAovG7vAu4eCfQ=
 github.com/mihaiav/ytdl v0.6.3-0.20200510100116-5f2bf8b4fec0/go.mod h1:F0WX8szfQ00mhmfla+0xVJp483SBV4VO/ByUaNioNSM=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -40,6 +48,7 @@ github.com/rs/zerolog v1.16.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tidwall/gjson v1.3.2 h1:+7p3qQFaH3fOMXAJSrdZwGKcOO/lYdGS0HqGhPqDdTI=

--- a/request/request.go
+++ b/request/request.go
@@ -168,7 +168,7 @@ func Headers(url, refer string) (http.Header, error) {
 	headers := map[string]string{
 		"Referer": refer,
 	}
-	res, err := Request(http.MethodGet, url, nil, headers)
+	res, err := Request(http.MethodHead, url, nil, headers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#397 add acfun bangumi download support, but normal videos are __not__ supported yet
* Cause acfun use m3u8 format file, it is hard to calculate the video size, so I omitted it.
* Change parameter ```http.MethodGet``` at ```Header``` method into ```http.MethodHead```
* [Limit display of parts](https://github.com/closetool/annie/blob/acfun/extractors/types/types.go#L21)