### PR TITLE
Bilibili 不支持 HEAD 请求，改回 GET 请求

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -168,7 +168,7 @@ func Headers(url, refer string) (http.Header, error) {
 	headers := map[string]string{
 		"Referer": refer,
 	}
-	res, err := Request(http.MethodHead, url, nil, headers)
+	res, err := Request(http.MethodGet, url, nil, headers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
向 Bilibili 发送 HEAD 请求时会返回 400 错误，改回 GET 请求来确保兼容性。

fix #881 
fix #843 