### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/extractors/extractors.go
+++ b/extractors/extractors.go
@@ -105,6 +105,9 @@ func Extract(u string, option types.Options) ([]*types.Data, error) {
 		}
 	}
 	extractor := extractorMap[domain]
+	if extractor == nil {
+		extractor = extractorMap[""]
+	}
 	videos, err := extractor.Extract(u, option)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```bash
# ./annie -v

annie: version 0.10.3, A fast, simple and clean video downloader.

# ./annie https://example.com
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x8b8265]

goroutine 1 [running]:
github.com/iawia002/annie/extractors.Extract(0x7ffeeb72af43, 0x13, 0x0, 0x0, 0x0, 0x1, 0x0, 0xa, 0x0, 0x0, ...)
	/Users/mac/iawia002/go/src/github.com/iawia002/annie/extractors/extractors.go:104 +0x2f5
main.download(0x7ffeeb72af43, 0x13, 0x1, 0x1)
	/Users/mac/iawia002/go/src/github.com/iawia002/annie/main.go:131 +0x18d
main.main()
	/Users/mac/iawia002/go/src/github.com/iawia002/annie/main.go:253 +0x26d
```

Related issues:
- iawia002/annie#852
- iawia002/annie#814
- iawia002/annie#794
- iawia002/annie#760
- iawia002/annie#754

fix #852
fix #814
fix #794
fix #760
fix #754