### PR TITLE
fix: the start parameter does not take effect

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -158,7 +158,7 @@ func ParseInputFile(r io.Reader, items string, itemStart, itemEnd int) []string 
 
 	itemList := make([]string, 0, len(wantedItems))
 	for i, item := range temp {
-		if ItemInSlice(i, wantedItems) {
+		if ItemInSlice(i+1, wantedItems) {
 			itemList = append(itemList, item)
 		}
 	}


### PR DESCRIPTION
当我使用`-F file.txt`读取文件中的地址下载`bilibili`分P视频时，文件中的第一个视频总是会被跳过，就像下面这个文件一样：
```
https://www.bilibili.com/video/BV1UW411x7v2?p=1
https://www.bilibili.com/video/BV1UW411x7v2?p=2
https://www.bilibili.com/video/BV1UW411x7v2?p=3
```
我通过文档了解到`start`默认值为1，但是加上`-start 0`也会跳过第一个视频，随即我查看源代码并修复，增加并通过了测试用例。

![image](https://user-images.githubusercontent.com/41336612/141830854-2e51f22a-4de2-4742-a556-d356167cd4eb.png)


When I use `-F file.txt` to read the address in the file to download `bilibili` split-P videos, the first video in the file is always skipped, as in the following file.
```
https://www.bilibili.com/video/BV1UW411x7v2?p=1
https://www.bilibili.com/video/BV1UW411x7v2?p=2
https://www.bilibili.com/video/BV1UW411x7v2?p=3
```
I learned from the documentation that `start` defaults to 1, but adding `-start 0` also skips the first video, so I then looked at the source code and fixed it, added and passed the test case.

![image](https://user-images.githubusercontent.com/41336612/141830854-2e51f22a-4de2-4742-a556-d356167cd4eb.png)