### PR TITLE
feat: Allow users to use specified user agent

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,11 @@ func main() {
 				Usage:   "Download playlist",
 			},
 			&cli.StringFlag{
+				Name:    "user-agent",
+				Aliases: []string{"u"},
+				Usage:   "Use specified User-Agent",
+			},
+			&cli.StringFlag{
 				Name:    "refer",
 				Aliases: []string{"r"},
 				Usage:   "Use specified Referrer",

--- a/main.go
+++ b/main.go
@@ -236,6 +236,7 @@ func main() {
 			request.SetOptions(request.Options{
 				RetryTimes: int(c.Uint("retry")),
 				Cookie:     cookie,
+				UserAgent:  c.String("user-agent"),
 				Refer:      c.String("refer"),
 				Debug:      c.Bool("debug"),
 				Silent:     c.Bool("silent"),

--- a/request/request.go
+++ b/request/request.go
@@ -90,7 +90,7 @@ func Request(method, url string, body io.Reader, headers map[string]string) (*ht
 	if userAgent != "" {
 		req.Header.Set("User-Agent", userAgent)
 	}
-	
+
 	if refer != "" {
 		req.Header.Set("Referer", refer)
 	}

--- a/request/request.go
+++ b/request/request.go
@@ -23,6 +23,7 @@ import (
 var (
 	retryTimes int
 	rawCookie  string
+	userAgent
 	refer      string
 	debug      bool
 )
@@ -31,6 +32,7 @@ var (
 type Options struct {
 	RetryTimes int
 	Cookie     string
+	UserAgent  string
 	Refer      string
 	Debug      bool
 	Silent     bool
@@ -40,6 +42,7 @@ type Options struct {
 func SetOptions(opt Options) {
 	retryTimes = opt.RetryTimes
 	rawCookie = opt.Cookie
+	userAgent = opt.UserAgent
 	refer = opt.Refer
 	debug = opt.Debug
 }
@@ -84,6 +87,10 @@ func Request(method, url string, body io.Reader, headers map[string]string) (*ht
 		}
 	}
 
+	if userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	
 	if refer != "" {
 		req.Header.Set("Referer", refer)
 	}

--- a/request/request.go
+++ b/request/request.go
@@ -23,7 +23,7 @@ import (
 var (
 	retryTimes int
 	rawCookie  string
-	userAgent
+	userAgent  string
 	refer      string
 	debug      bool
 )


### PR DESCRIPTION
By the way,  should we use newer user agent as default options?
e.g. `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36`